### PR TITLE
Restructured mkdocs to make it consistent with documentation hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 site/
+.vscode
+venv/

--- a/docs setup/Readme.md
+++ b/docs setup/Readme.md
@@ -1,0 +1,56 @@
+# Guide to run this documentation locally
+
+## 1. Create a Virtual Environment
+
+Run the following command in your project directory:
+
+```bash
+python -m venv venv
+```
+
+This will create a folder named **`venv`** containing the virtual environment.
+
+---
+
+## 2. Activate the Virtual Environment
+
+To start using the virtual environment:
+
+* **On macOS/Linux:**
+
+  ```bash
+  source venv/bin/activate
+  ```
+
+* **On Windows (Git Bash):**
+
+  ```powershell
+  source venv/Scripts/activate
+  ```
+
+---
+
+## 3. Install Dependencies
+
+If you have a `requirements.txt` file in your project:
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## 4. Serve the Mkdocs locally
+
+```
+mkdocs serve
+```
+This will start the mkdocs server
+
+## 5 ( Optional ). Deactivate the Virtual Environment
+
+When finished working, you can exit the environment with:
+
+```bash
+deactivate
+```

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -8,7 +8,7 @@
 }
 /* This automatically stretches the site contents to monitor width*/
 .md-grid {
-    max-width: initial;
+    max-width: 90vw;
 }
 /* Preserve words so they are not broken in the middle on newlines */
 .md-typeset td {
@@ -19,4 +19,9 @@
     /* top | right | bottom | left */
     padding: 3px 2px;
     font-size: 12px;
+}
+
+.md-header__button.md-logo{
+    padding-bottom: 18px;
+    scale: 1.2;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,23 +11,57 @@ theme:
   name: material
   logo: osipiImgs/OSIPI_logo.png
   favicon: osipiImgs/OSIPI_logo_only_square.png
+  features:
+    - announce.dismiss
+    - content.action.edit
+    - content.action.view
+    - content.code.annotate
+    - content.code.copy
+    # - content.code.select
+    # - content.footnote.tooltips
+    # - content.tabs.link
+    - content.tooltips
+    # - header.autohide
+    # - navigation.expand
+    - navigation.footer
+    - navigation.indexes
+    # - navigation.instant
+    # - navigation.instant.prefetch
+    # - navigation.instant.progress
+    # - navigation.prune
+    # - navigation.sections
+    - navigation.tabs
+    # - navigation.tabs.sticky
+    - navigation.top
+    - navigation.tracking
+    - search.highlight
+    - search.share
+    - search.suggest
+    - toc.follow
+    # - toc.integrate
   palette:
-
-    # Palette toggle for light mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/link
+        name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
+      primary: indigo
+      accent: indigo
       toggle:
-        icon: material/weather-sunny
+        icon: material/toggle-switch
         name: Switch to dark mode
-
-    # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
+      primary: black
+      accent: indigo
       toggle:
-        icon: material/weather-night
-        name: Switch to light mode
-  features:
-    - search.suggest
+        icon: material/toggle-switch-off
+        name: Switch to system preference
+  font:
+    text: Roboto
+    code: Roboto Mono
+
   icon:
     admonition:
       note: fontawesome/solid/note-sticky
@@ -63,6 +97,9 @@ plugins:
   - search:
       lang: en
       separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
+  - minify:
+      minify_html: true
+  - open-in-new-tab
 
 markdown_extensions:
   - toc:
@@ -102,17 +139,13 @@ extra:
     description: CAPLEX
     image: Social Card.png
     url: https://osipi.github.io/OSIPI_CAPLEX/
+    
+  social:
+  - icon: fontawesome/brands/github
+    link: https://github.com/OSIPI
+  - icon: fontawesome/brands/slack
+    link: https://app.slack.com/client/TFGVCE9HS
 
-extra_javascript:
-  - javascripts/extra.js
-  - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML
-
-extra_css:
-  - stylesheets/extra.css
-
-extra:
   analytics:
     provider: google
     property: G-27M7GKVZFQ
@@ -138,3 +171,12 @@ extra:
       as to measure the effectiveness of our lexicon and whether users
       find what they're searching for. With your consent, you're helping us to
       make our lexicon better.
+
+extra_javascript:
+  - javascripts/extra.js
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML
+
+extra_css:
+  - stylesheets/extra.css

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs
+mkdocs-material
+mkdocs-material-extensions
+mkdocs-minify-plugin
+mkdocs-open-in-new-tab


### PR DESCRIPTION
## Restructured mkdocs to make it consistent with documentation hub

### Before
<img width="1902" height="859" alt="image" src="https://github.com/user-attachments/assets/142db81b-2938-4359-a426-6d8436627af1" />

### After
<img width="1888" height="864" alt="image" src="https://github.com/user-attachments/assets/2fddc52c-0f9f-4b31-84c2-fdb4f814a80c" />
